### PR TITLE
Various bugfixes, SkipFE and minor improvements

### DIFF
--- a/fallen/DDEngine/Source/figure.cpp
+++ b/fallen/DDEngine/Source/figure.cpp
@@ -2727,6 +2727,16 @@ void FIGURE_draw_prim_tween(
 
     LOG_ENTER(Figure_Draw_Prim_Tween)
 
+    ASSERT(p_thing)
+
+    if (!p_thing)
+        return;
+
+    ASSERT(p_thing->Genus.Person)
+
+    if (!p_thing->Genus.Person)
+        return;
+
     tex_page_offset = p_thing->Genus.Person->pcom_colour & 0x3;
 
     //

--- a/fallen/DDEngine/Source/figure.cpp
+++ b/fallen/DDEngine/Source/figure.cpp
@@ -2727,12 +2727,8 @@ void FIGURE_draw_prim_tween(
 
     LOG_ENTER(Figure_Draw_Prim_Tween)
 
-    ASSERT(p_thing)
-
     if (!p_thing)
         return;
-
-    ASSERT(p_thing->Genus.Person)
 
     if (!p_thing->Genus.Person)
         return;

--- a/fallen/DDLibrary/Source/D3DTexture.cpp
+++ b/fallen/DDLibrary/Source/D3DTexture.cpp
@@ -3,6 +3,7 @@
 
 #include "DDLib.h"
 #include "tga.h"
+#include <Windows.h>
 
 #ifdef TARGET_DC
 #include "target.h"
@@ -204,8 +205,23 @@ HRESULT D3DTexture::LoadTextureTGA(char* tga_file, std::uint32_t id, bool bCanSh
     result = Reload();
 
     if (FAILED(result)) {
-        DebugText("LoadTextureTGA: unable to load texture\n");
-        return (result);
+        char buf[MAX_PATH];
+
+        if (tga_file[1] != ':')
+        {
+            GetCurrentDirectoryA(MAX_PATH, buf);
+            strcat(buf, "\\");
+        }
+        strcat(buf, tga_file);
+
+        DebugText("LoadTextureTGA: unable to load texture: %s\n", buf);
+
+        if (strcmp(tga_file, "DEFAULTTEXTURE.tga") == 0)
+            return (result);
+
+        DebugText("LoadTextureTGA: falling back to DEFAULTTEXTURE...\n");
+        //return (result);
+        return LoadTextureTGA("DEFAULTTEXTURE.tga", id, bCanShrink);
     }
 
     //

--- a/fallen/DDLibrary/Source/D3DTexture.cpp
+++ b/fallen/DDLibrary/Source/D3DTexture.cpp
@@ -3,7 +3,7 @@
 
 #include "DDLib.h"
 #include "tga.h"
-#include <Windows.h>
+#include <string>
 
 #ifdef TARGET_DC
 #include "target.h"
@@ -205,19 +205,21 @@ HRESULT D3DTexture::LoadTextureTGA(char* tga_file, std::uint32_t id, bool bCanSh
     result = Reload();
 
     if (FAILED(result)) {
-        char buf[MAX_PATH];
+        std::string buf;
 
         if (tga_file[1] != ':')
         {
-            GetCurrentDirectoryA(MAX_PATH, buf);
-            strcat(buf, "\\");
+            size_t sizeCurrDir = GetCurrentDirectoryA(0, NULL);
+            buf.resize(sizeCurrDir + 1);
+            GetCurrentDirectoryA(sizeCurrDir, buf.data());
+            buf += '\\';
         }
-        strcat(buf, tga_file);
+        buf += tga_file;
 
-        DebugText("LoadTextureTGA: unable to load texture: %s\n", buf);
+        DebugText("LoadTextureTGA: unable to load texture: %s\n", buf.c_str());
 
         if (strcmp(tga_file, "DEFAULTTEXTURE.tga") == 0)
-            return (result);
+            return result;
 
         DebugText("LoadTextureTGA: falling back to DEFAULTTEXTURE...\n");
         //return (result);

--- a/fallen/DDLibrary/Source/GDisplay.cpp
+++ b/fallen/DDLibrary/Source/GDisplay.cpp
@@ -258,7 +258,7 @@ std::int32_t OpenDisplay(std::uint32_t width, std::uint32_t height, std::uint32_
     extern HINSTANCE hGlobalThisInst;
 
     VideoRes = ENV_get_value_number("video_res", -1, "Render");
-    VideoRes = std::max(std::min(VideoRes, 4), 0);
+    //VideoRes = std::max(std::min(VideoRes, 4), 0);
 
     depth = 32;
     switch (VideoRes) {
@@ -289,13 +289,24 @@ std::int32_t OpenDisplay(std::uint32_t width, std::uint32_t height, std::uint32_
         // case 5:		width = 1920; height = 1080; break;		// TODO: Investigate modern screen resolutions
     }
 
+    if (VideoRes < -1)
+    {
+        width = ENV_get_value_number("video_width", 1280, "Render");
+        height = ENV_get_value_number("video_height", 720, "Render");
+    }
+
     if (flags & FLAGS_USE_3D)
         the_display.Use3DOn();
 
     if (flags & FLAGS_USE_WORKSCREEN)
         the_display.UseWorkOn();
 
-    the_display.FullScreenOn();
+    //the_display.FullScreenOn();
+
+    if (ENV_get_value_number("fullscreen_mode", -1, "Render") == 0)
+        the_display.FullScreenOff();
+    else
+        the_display.FullScreenOn();
 
     result = SetDisplay(width, height, depth);
 
@@ -795,7 +806,8 @@ HRESULT Display::InitFullscreenMode() {
         // Set window style.
         style = GetWindowStyle(hDDLibWindow);
         style &= ~WS_POPUP;
-        style |= WS_OVERLAPPED | WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX;
+        //style |= WS_OVERLAPPED | WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX;
+        style |= WS_OVERLAPPEDWINDOW;
         SetWindowLong(hDDLibWindow, GWL_STYLE, style);
 
         // Save Surface Rectangle.

--- a/fallen/DDLibrary/Source/GHost.cpp
+++ b/fallen/DDLibrary/Source/GHost.cpp
@@ -6,6 +6,7 @@
 #include "mfx.h"
 
 #include <shellapi.h>
+#include <string>
 
 #define PAUSE_TIMEOUT 500
 #define PAUSE (1 << 0)
@@ -413,9 +414,10 @@ void GetArgs()
     for (int i = 0; i < argcW; i++) {
         // Convert wide-char to multibyte (ANSI or system code page)
         int len = WideCharToMultiByte(CP_ACP, 0, argvW[i], -1, nullptr, 0, nullptr, nullptr);
-        char* arg = (char*)malloc(len);
-        WideCharToMultiByte(CP_ACP, 0, argvW[i], -1, arg, len, nullptr, nullptr);
-        argv[i] = arg;
+        std::string* arg = new std::string();
+        arg->resize(len);
+        WideCharToMultiByte(CP_ACP, 0, argvW[i], -1, arg->data(), len, nullptr, nullptr);
+        argv[i] = arg->data();
     }
 
     LocalFree(argvW);

--- a/fallen/DDLibrary/Source/GHost.cpp
+++ b/fallen/DDLibrary/Source/GHost.cpp
@@ -5,6 +5,8 @@
 #include "..\headers\Sound.h"
 #include "mfx.h"
 
+#include <shellapi.h>
+
 #define PAUSE_TIMEOUT 500
 #define PAUSE (1 << 0)
 #define PAUSE_ACK (1 << 1)
@@ -400,6 +402,25 @@ void Time(MFTime* the_time) {
 static std::uint16_t argc;
 static LPTSTR argv[MAX_PATH];
 
+void GetArgs()
+{
+    int argcW = 0;
+    LPWSTR* argvW = CommandLineToArgvW(GetCommandLineW(), &argcW);
+    if (!argvW)
+        return;
+
+    argc = argcW;
+    for (int i = 0; i < argcW; i++) {
+        // Convert wide-char to multibyte (ANSI or system code page)
+        int len = WideCharToMultiByte(CP_ACP, 0, argvW[i], -1, nullptr, 0, nullptr, nullptr);
+        char* arg = (char*)malloc(len);
+        WideCharToMultiByte(CP_ACP, 0, argvW[i], -1, arg, len, nullptr, nullptr);
+        argv[i] = arg;
+    }
+
+    LocalFree(argvW);
+}
+
 #ifdef TARGET_DC
 // Include this again in just one file - this one.
 #include "dtags.h"
@@ -464,6 +485,7 @@ int WINAPI WinMain(HINSTANCE hThisInst, HINSTANCE hPrevInst, LPTSTR lpszArgs, in
     if (GetLastError() != ERROR_ALREADY_EXISTS)
 #endif
     {
+        GetArgs();
         return MF_main(argc, argv);
     }
 

--- a/fallen/DDLibrary/Source/Tga.cpp
+++ b/fallen/DDLibrary/Source/Tga.cpp
@@ -122,7 +122,19 @@ TGA_Info TGA_load(const char* file, std::int32_t max_width, std::int32_t max_hei
     }
 
     // read compressed
-    return TGA_read_compressed(data, id, max_width, max_height);
+    TGA_Info ret;
+
+    ret = TGA_read_compressed(data, id, max_width, max_height);
+
+    
+    if (!ret.valid)
+    {
+        // try file
+        ret = TGA_load_from_file(file, max_width, max_height, data, bCanShrink);
+    }
+
+    //return TGA_read_compressed(data, id, max_width, max_height);
+    return ret;
 #endif
 }
 

--- a/fallen/DDLibrary/Source/WindProcs.cpp
+++ b/fallen/DDLibrary/Source/WindProcs.cpp
@@ -80,11 +80,11 @@ LRESULT CALLBACK DDLibShellProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM l
     case WM_KEYUP:
         KeyboardProc(message, wParam, lParam);
         break;
-    case WM_CLOSE:
-        // normally, we should call DestroyWindow().
-        // instead, let's set flags so the normal quit process goes thru.
-        GAME_STATE = 0;
-        break;
+    //case WM_CLOSE:
+    //    // normally, we should call DestroyWindow().
+    //    // instead, let's set flags so the normal quit process goes thru.
+    //    GAME_STATE = 0;
+    //    break;
     case WM_DESTROY:
         PostQuitMessage(0);
         break;

--- a/fallen/Fallen.vcxproj
+++ b/fallen/Fallen.vcxproj
@@ -117,7 +117,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level2</WarningLevel>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PreprocessorDefinitions>_WINDOWS;WIN32;_DEBUG;NDEBUG;VERSION_D3D;TEX_EMBED;WINDOWS_IGNORE_PACKING_MISMATCH;HIGH_REZ_PEOPLE_PLEASE_BOB;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;WIN32;_DEBUG;DEBUG;NDEBUG;VERSION_D3D;TEX_EMBED;WINDOWS_IGNORE_PACKING_MISMATCH;HIGH_REZ_PEOPLE_PLEASE_BOB;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\Debug\Fallen.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>$(IntDir)</ObjectFileName>

--- a/fallen/Fallen.vcxproj
+++ b/fallen/Fallen.vcxproj
@@ -117,7 +117,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WarningLevel>Level2</WarningLevel>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
-      <PreprocessorDefinitions>_WINDOWS;WIN32;_DEBUG;DEBUG;NDEBUG;VERSION_D3D;TEX_EMBED;WINDOWS_IGNORE_PACKING_MISMATCH;HIGH_REZ_PEOPLE_PLEASE_BOB;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINDOWS;WIN32;_DEBUG;DEBUG;VERSION_D3D;TEX_EMBED;WINDOWS_IGNORE_PACKING_MISMATCH;HIGH_REZ_PEOPLE_PLEASE_BOB;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>$(IntDir)</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\Debug\Fallen.pch</PrecompiledHeaderOutputFile>
       <ObjectFileName>$(IntDir)</ObjectFileName>

--- a/fallen/Headers/Game.h
+++ b/fallen/Headers/Game.h
@@ -547,3 +547,11 @@ void stop_all_fx_and_music();
 #define POLY_T (POLY_FLAG_TEXTURED)
 #define POLY_G (POLY_FLAG_GOURAD)
 #define POLY_F (0)
+
+//
+// SkipFE stuff
+//
+void SetSkipFE(bool state);
+bool GetSkipFE();
+void SetSkipFELevel(const char* filename);
+char* GetSkipFELevel();

--- a/fallen/Source/Attract.cpp
+++ b/fallen/Source/Attract.cpp
@@ -124,6 +124,17 @@ void game_attract_mode() {
     NIGHT_init();
 #endif
 
+    if (GetSkipFE())
+    {
+        GAME_STATE &= ~GS_ATTRACT_MODE;
+        GAME_STATE |= GS_PLAY_GAME;
+        go_into_game = true;
+
+        extern char STARTSCR_mission[_MAX_PATH];
+        strcpy(STARTSCR_mission, GetSkipFELevel());
+        SetSkipFE(false);
+    }
+
     if (auto_advance) {
         go_into_game = true;
         auto_advance = 0;
@@ -324,6 +335,18 @@ reinit_because_of_language_change:
 
                 GAME_STATE |= GS_PLAYBACK;
             }
+        }
+
+        if (ControlFlag && LastKey == KB_O) {
+            LastKey = 0;
+            GAME_STATE &= ~GS_ATTRACT_MODE;
+            GAME_STATE |= GS_PLAY_GAME;
+            go_into_game = true;
+            
+            //extern char STARTSCR_mission[_MAX_PATH];
+            //strcpy(STARTSCR_mission, "levels\\test.ucm");
+
+            //GAME_STATE |= GS_PLAYBACK;
         }
 
 #ifdef TARGET_DC

--- a/fallen/Source/Game.cpp
+++ b/fallen/Source/Game.cpp
@@ -1626,9 +1626,9 @@ std::int32_t special_keys() {
         playback_game_keys();
     }
 
-    //if (ControlFlag && Keys[KB_Q]) {
-    //    return 1;
-    //}
+    if (ControlFlag && Keys[KB_Q]) {
+        return 1;
+    }
 #ifndef PSX
     if (allow_debug_keys)
         if (Keys[KB_QUOTE]) {

--- a/fallen/Source/Game.cpp
+++ b/fallen/Source/Game.cpp
@@ -115,6 +115,34 @@ extern std::int32_t PSX_eog_timer;
 #endif
 
 //
+// SkipFE stuff
+//
+
+bool SkipFE = false;
+char SkipFELevel[MAX_PATH];
+
+void SetSkipFE(bool state)
+{
+    SkipFE = state;
+}
+
+bool GetSkipFE()
+{
+    return SkipFE;
+}
+
+void SetSkipFELevel(const char* filename)
+{
+    strcpy_s(SkipFELevel, filename);
+}
+
+char* GetSkipFELevel()
+{
+    return SkipFELevel;
+}
+
+
+//
 // The editor.
 //
 
@@ -1598,9 +1626,9 @@ std::int32_t special_keys() {
         playback_game_keys();
     }
 
-    if (ControlFlag && Keys[KB_Q]) {
-        return 1;
-    }
+    //if (ControlFlag && Keys[KB_Q]) {
+    //    return 1;
+    //}
 #ifndef PSX
     if (allow_debug_keys)
         if (Keys[KB_QUOTE]) {

--- a/fallen/Source/Main.cpp
+++ b/fallen/Source/Main.cpp
@@ -231,6 +231,15 @@ std::int32_t main(std::uint16_t argc, TCHAR* argv[]) {
 #endif
 #endif
 
+    if (argc >= 2)
+    {
+        if (FileExists(argv[1]))
+        {
+            SetSkipFELevel(argv[1]);
+            SetSkipFE(true);
+        }
+    }
+
     if (SetupHost(H_CREATE_LOG)) {
         //		mkt_test();
 

--- a/fallen/Source/supermap.cpp
+++ b/fallen/Source/supermap.cpp
@@ -1977,6 +1977,8 @@ void load_super_map(MFFileHandle handle, std::int32_t save_type) {
                         FileSeek(handle,SEEK_MODE_CURRENT,sizeof(OB_Mapwho)*OB_SIZE*OB_SIZE);
         */
         FileRead(handle, (std::uint8_t*) &OB_ob_upto, sizeof(OB_ob_upto));
+        ASSERT((uint32_t)OB_ob_upto < OB_MAX_OBS);
+
         FileRead(handle, (std::uint8_t*) &OB_ob[0], sizeof(OB_Ob) * OB_ob_upto);
 
         //


### PR DESCRIPTION
Here's what's been done:
- Added additional asserts for certain conditions that could crash the game
- Prevent loading of figure tweens in case there isn't a figure pointer or a genus pointer
- Texture loading fallback to load from file in case it isn't found in the clump
- Fallback to texture `DEFAULTTEXTURE.tga` in case the requested texture doesn't exist
- Option to use a custom window width and height by `video_width` and `video_height` -- this will need some extra care for fullscreen, it's mostly put here for windowed mode use. You can enable the use of these variables by setting `video_res` to -2
- Option to enable/disable fullscreen with `fullscreen_mode`
- Changed the window style for Release build to have the control buttons
- Argument parsing in Win32
- SkipFE - you can pass a level file path to the game as the first argument to insta-load the level -- example: `fallen levels\e3.ucm`. Note that your working directory must stay inside the game directory!
- Disabled WM_CLOSE case to allow for normal window closing during gameplay
- Added an option at the attract/menu screen for both Debug and Release - press Ctrl+O to open a level file (instead of relying on janky replay mode to open levels)

I would've loved to use more modern approaches (such as not using MAX_PATH and use `std::filesystem::path`) but I didn't want to stray too far away from the original code (as I can see that you're already planning a C++ rewrite/extension).